### PR TITLE
Refactor project layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GIT_COMMIT=$(shell git rev-parse HEAD)
 LDFLAGS=-ldflags "-X main.GitCommit=$(GIT_COMMIT)"
 
 build:
-	@go build $(LDFLAGS) -o bin/slip slip/main.go
+	@go build $(LDFLAGS) -o bin/slip main.go
 
 test:
 	@go test ./...

--- a/internal/core.go
+++ b/internal/core.go
@@ -1,4 +1,4 @@
-package slip
+package internal
 
 import (
 	"fmt"

--- a/internal/env.go
+++ b/internal/env.go
@@ -1,0 +1,26 @@
+package internal
+
+type Enviroment struct {
+	symbols map[string]Object
+	parent  *Enviroment
+}
+
+func NewEnviroment() *Enviroment {
+	return &Enviroment{symbols: make(map[string]Object)}
+}
+
+func NewChildEnviroment(parent *Enviroment) *Enviroment {
+	return &Enviroment{symbols: make(map[string]Object), parent: parent}
+}
+
+func (self *Enviroment) Define(sym *Symbol, obj Object) {
+	self.symbols[sym.Value] = obj
+}
+
+func (self *Enviroment) Resolve(sym *Symbol) Object {
+	obj := self.symbols[sym.Value]
+	if obj == nil && self.parent != nil {
+		return self.parent.Resolve(sym)
+	}
+	return obj
+}

--- a/internal/object.go
+++ b/internal/object.go
@@ -1,4 +1,4 @@
-package slip
+package internal
 
 import (
 	"fmt"

--- a/internal/reader.go
+++ b/internal/reader.go
@@ -1,4 +1,4 @@
-package slip
+package internal
 
 import (
 	"strconv"

--- a/internal/slip.go
+++ b/internal/slip.go
@@ -1,4 +1,4 @@
-package slip
+package internal
 
 import (
 	"fmt"
@@ -8,9 +8,6 @@ import (
 
 	"github.com/peterh/liner"
 )
-
-////////////////////////////////////////////////////////////////////////////////
-// Slip
 
 type Slip struct {
 	env    *Enviroment
@@ -69,32 +66,4 @@ func (self *Slip) Exec(src string) Object {
 	self.reader.Init(src)
 	obj := self.reader.Read()
 	return obj.Eval(self.env)
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Enviroment
-
-type Enviroment struct {
-	symbols map[string]Object
-	parent  *Enviroment
-}
-
-func NewEnviroment() *Enviroment {
-	return &Enviroment{symbols: make(map[string]Object)}
-}
-
-func NewChildEnviroment(parent *Enviroment) *Enviroment {
-	return &Enviroment{symbols: make(map[string]Object), parent: parent}
-}
-
-func (self *Enviroment) Define(sym *Symbol, obj Object) {
-	self.symbols[sym.Value] = obj
-}
-
-func (self *Enviroment) Resolve(sym *Symbol) Object {
-	obj := self.symbols[sym.Value]
-	if obj == nil && self.parent != nil {
-		return self.parent.Resolve(sym)
-	}
-	return obj
 }

--- a/internal/slip_test.go
+++ b/internal/slip_test.go
@@ -1,11 +1,11 @@
-package slip
+package internal
 
 import (
 	"fmt"
 	"testing"
 )
 
-func TestSlip(t *testing.T) {
+func TestSlip_Exec(t *testing.T) {
 	cases := []struct {
 		Src, Res string
 	}{

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dbrabera/slip"
+	"github.com/dbrabera/slip/internal"
 )
 
 const Version = "0.0.1"
@@ -59,7 +59,7 @@ func main() {
 		os.Exit(version())
 	}
 
-	sl := slip.NewSlip()
+	sl := internal.NewSlip()
 
 	if options.Script != "" {
 		os.Exit(sl.Run(options.Script))


### PR DESCRIPTION
Moves `main.go` to the top level directory and all the rest of the Go code to the `internal` package.