### PR TITLE
Setup linting with golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ go_import_path: github.com/dbrabera/slip
 go:
   - "1.14"
 
+install:
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
+
 script:
   - make build
+  - make lint
   - make test

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@ LDFLAGS=-ldflags "-X $(PACKAGE)/internal.Version=$(VERSION)"
 build:
 	@go build $(LDFLAGS) -o bin/slip main.go
 
+lint:
+	@golangci-lint run ./...
+
 test:
 	@go test ./...
 
 clean:
 	@rm -rf bin
 
-.PHONY: build test clean
+.PHONY: build lint test clean

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ It's ALIVE!
 ### Prerequisites
 
 - Go (1.14 or later)
+- Golangci-lint (1.27 or later)
 
 ### Build
 
@@ -47,6 +48,14 @@ To build the source code do:
 
 ```
 $ make build
+```
+
+### Lint
+
+To lint the source code do:
+
+```
+$ make lint
 ```
 
 ### Test


### PR DESCRIPTION
Setups a Makefile target to lint using `golangci-lint` and configures it to be executed on the CI pipeline.