### PR TITLE
Comments

### DIFF
--- a/examples/alive.sp
+++ b/examples/alive.sp
@@ -1,1 +1,0 @@
-(println "It's ALIVE!")

--- a/examples/hello.sp
+++ b/examples/hello.sp
@@ -1,0 +1,3 @@
+; Prints "Hello, world!" to stdout
+
+(println "Hello, world!")

--- a/internal/lexer.go
+++ b/internal/lexer.go
@@ -98,6 +98,11 @@ func (l *Lexer) Next() (*Token, error) {
 	}
 
 	switch {
+	case r == ';':
+		if err := l.skipLine(); err != nil {
+			return nil, err
+		}
+		return l.Next()
 	case r == '(':
 		return &Token{TLeftParen, ""}, nil
 	case r == ')':
@@ -177,6 +182,19 @@ func (l *Lexer) skipWhitespace() error {
 			if err := l.unread(); err != nil {
 				return err
 			}
+			return nil
+		}
+	}
+}
+
+func (l *Lexer) skipLine() error {
+	for {
+		r, err := l.read()
+		if err != nil {
+			return nil
+		}
+
+		if r == '\n' {
 			return nil
 		}
 	}

--- a/internal/lexer_test.go
+++ b/internal/lexer_test.go
@@ -18,6 +18,8 @@ func TestTokenize(t *testing.T) {
 		{"- -1 -a", []TokenKind{TSymbol, TInt, TSymbol}},
 		{"true false foo", []TokenKind{TBool, TBool, TSymbol}},
 		{"!@$%^&*-_+=|~:<>.?\\/,", []TokenKind{TSymbol}},
+		{"; foo", []TokenKind{}},
+		{"1 ; foo\n 2", []TokenKind{TInt, TInt}},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
Adds support for comments at the lexer level.

Comments start by `;` and finish and the end of the line, and are skipped during tokenization.